### PR TITLE
Enable full offline mode

### DIFF
--- a/MRO V.5.5 00/backgroundscript.js
+++ b/MRO V.5.5 00/backgroundscript.js
@@ -10,6 +10,9 @@ var mainGrowbotTabId = 0;
 var lastStoryAcct;
 var clickedViewStoryTabIds = [];
 
+// Local authorization flag ensures the extension runs entirely offline
+const isUserAuthorized = true;
+
 
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 
@@ -216,7 +219,7 @@ var gblIgBotUser = {
     install_date: new Date().toUTCString(),
     instabot_install_date: undefined,
     ig_users: [],
-    licenses: { "growbot_license": 1 }, // Sempre tem licença
+    licenses: { "growbot_license": isUserAuthorized ? 1 : 0 }, // Sempre tem licença local
     actions: [{
         date: '',
         action: ''
@@ -350,7 +353,7 @@ async function checkInstallDate() {
     gblIgBotUser.install_date = new Date(+installDate).toUTCString();
     
     // Sempre envia que tem licença
-    allLicensesFetched(1, { "growbot_license": 1 });
+    allLicensesFetched(1, { "growbot_license": isUserAuthorized ? 1 : 0 });
 }
 
 function sendMessageToInstagramTabs(message) {
@@ -369,7 +372,7 @@ function allLicensesFetched(count, licenses) {
     // Sempre envia que tem licença válida
     sendMessageToInstagramTabs({
         "instabot_install_date": gblIgBotUser.instabot_install_date,
-        "instabot_has_license": true,
+        "instabot_has_license": isUserAuthorized,
         igBotUser: gblIgBotUser
     });
 

--- a/MRO V.5.5 00/contentscript.js
+++ b/MRO V.5.5 00/contentscript.js
@@ -7,7 +7,7 @@
  */
 
 // Local authorization flag replaces the old remote login system
-const isAuthorized = true;
+const isUserAuthorized = true;
 
 // Initialize fake authentication data so logic relying on these values keeps working
 if (!localStorage.getItem('gbUserGuid')) {
@@ -262,7 +262,7 @@ var gblCheckboxPlugin;
 var instabot_install_date = 0; // set from background page
 var instabot_free_trial_time = 0; // set from background page
 // Authorization state used throughout the extension
-var instabot_has_license = isAuthorized;
+var instabot_has_license = isUserAuthorized;
 
 var defaultFilterOptions = {
     applyFiltersAutomatically: true,
@@ -7267,7 +7267,7 @@ function userUpdateListener() {
 
             if (request.instabot_has_license) {
                 // Ignore external license checks; use local authorization flag
-                instabot_has_license = isAuthorized;
+                instabot_has_license = isUserAuthorized;
 
                 if (request.igBotUser) {
                     localStorage['gbUserGuid'] = request.igBotUser.user_guid;


### PR DESCRIPTION
## Summary
- set `isUserAuthorized` constant for offline authorization
- propagate local authorization throughout background and content scripts

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688678e4df5c832bb72832e7c18ae1fd